### PR TITLE
Added authentication and impersonation handling

### DIFF
--- a/package/run-sparkling.sh
+++ b/package/run-sparkling.sh
@@ -37,6 +37,12 @@ if [ ! -z "$EGO_DEFAULT_FS_DC" ]; then
     H2O_SPARK_CONF+=" --conf spark.ego.dataconnectors.defaultfs=$EGO_DEFAULT_FS_DC"
 fi
 
+if [ ! -z "$EGO_IMPERSONATE_CREDENTIAL" ]; then
+    H2O_SPARK_CONF+=" --conf spark.ego.credential=$EGO_IMPERSONATE_CREDENTIAL"
+elif [ ! -z "$EGO_SERVICE_CREDENTIAL" ]; then
+    H2O_SPARK_CONF+=" --conf spark.ego.credential=$EGO_SERVICE_CREDENTIAL"
+fi
+
 if [ "${NOTEBOOK_SSL_ENABLED}" == "true" ]; then
         spark-submit "$@" $VERBOSE --driver-class-path "$TOPDIR/jars/httpclient-4.5.2.jar" --conf "spark.executor.extraClassPath=$TOPDIR/jars/httpclient-4.5.2.jar" --driver-memory "$DRIVER_MEMORY" --master "$MASTER" $H2O_SPARK_CONF --conf spark.ext.h2o.jks="$H2O_KEYSTORE" --conf spark.driver.extraJavaOptions="$EXTRA_DRIVER_PROPS" --class "$DRIVER_CLASS" "$FAT_JAR_FILE"
 else

--- a/scripts/jobMonitor.sh
+++ b/scripts/jobMonitor.sh
@@ -13,7 +13,7 @@ do
             retrialtime=$(($retrialtime + 1))
             IPID=`ps -elf | grep -i water.SparklingWaterDriver | grep $EGOSC_SERVICE_NAME | grep -vi wrapper | grep -vi grep | grep -vi tail | awk '{print $4}'`
             if [ -n "$IPID" ]; then
-               port=`netstat -anp | grep LISTEN | grep $IPID/java | grep ":::[1-9]" | grep ":::54" | awk '{print $4}' | awk -F':' '{print $4}'`
+	       port=`netstat -anp | grep LISTEN | grep $IPID/java | grep "0.0.0.0:[1-9]" | grep "0.0.0.0:54" | awk '{print $4}' | awk -F':' '{print $2}'`
                if [ -n "$port" ]; then
                   break
                fi


### PR DESCRIPTION
In case IBM Spectrum Conductor uses Spark Instance Group (SIG) with enabled authentication then add  spark.ego.credential property with internal EGO credential token generated for H2O Sparkling Water service. Since Conductor provides option to enable impersonation for the H2O Notebook (i.e. run all the Notebook processes as its OS user owner then the patch will use EGO credential generated for impersonated user, otherwise credentials for SIG's OS execution user will be used.